### PR TITLE
Add option to use sparse delay embedding

### DIFF
--- a/mwf/+mwf_utils/stack_delay_data_sparse.m
+++ b/mwf/+mwf_utils/stack_delay_data_sparse.m
@@ -1,0 +1,48 @@
+% Stack delayed versions of the input (multi-channel) data together.
+% Zero-padding is applied to the delayed signals to ensure that samples per
+% channel of the output data y_s remains the same as the input data y.
+%
+% INPUTS:
+%   y       raw EEG data (channels x samples)
+%   delay   maximum time delay to include
+%   singlesided     [default 0] use single sided or double sided delays
+%                   if 1, use only positive time delays up to 'delay'
+%                   if 0, use positive and negative time delays up to 'delay'
+%
+% OUTPUTS: 
+%   y_s     raw EEG data, included delayed versions (channels x samples)
+%   M_s     number of channels in y_s
+%
+% Author: Ben Somers, KU Leuven, Department of Neurosciences, ExpORL
+% Correspondence: ben.somers@med.kuleuven.be
+
+%% NWB added option to space out the delay stacking
+
+function [y_s, M_s] = stack_delay_data_sparse(y, delay, singlesided, delay_spacing)
+
+if nargin < 3
+    singlesided = false;
+end
+
+M = size(y,1);
+
+if singlesided
+    M_s = (delay + 1) * M;
+    y_s = zeros(M_s, size(y,2));
+    for tau = 0:delay
+        y_shift = circshift(y, [0, tau*delay_spacing]);
+        y_shift(:, [1:tau*delay_spacing, end+tau*delay_spacing+1:end]) = 0;
+        y_s(tau*M+1 : M*(tau+1) , :) = y_shift;   
+    end
+else
+    M_s = (2 * delay + 1) * M;
+    y_s = zeros(M_s, size(y,2));
+    for tau = -delay:delay
+        y_shift = circshift(y, [0, tau*delay_spacing]);
+        y_shift(:, [1:tau*delay_spacing, end+tau*delay_spacing+1:end]) = 0;
+        y_s((tau+delay)*M+1 : M*(tau+delay+1) , :) = y_shift;
+    end
+end
+
+
+end

--- a/mwf/mwf_apply_sparse.m
+++ b/mwf/mwf_apply_sparse.m
@@ -1,0 +1,51 @@
+% Apply a pre-computed Multi-channel Wiener Filter W on a multi-channel EEG
+% signal y, producing artifact estimate d and filtered signal n.
+%
+% This function works for input EEG with a DC component. As the MWF is 
+% computed on zero-meaned data, it should be applied on zero-meaned
+% data as well. Therefore, the mean of the EEG data is subtracted first
+% and added after MWF application. 
+%
+% INPUTS:
+%   y       raw EEG data (channels x samples)
+%   W       precomputed multi-channel Wiener filter
+%
+% OUTPUTS: 
+%   n       filtered EEG data (channels x samples)
+%   d       estimated artifacts in every channel (channels x samples)
+%
+% Author: Ben Somers, KU Leuven, Department of Neurosciences, ExpORL
+% Correspondence: ben.somers@med.kuleuven.be
+
+%% NWB added option to space out the delay stacking
+
+function [n, d] = mwf_apply_sparse(y, W,delay_spacing)
+
+mwf_utils.check_dimensions(size(y));
+
+[M, T] = size(y);
+M_s = size(W, 1);
+
+tau = (M_s - M) / (2 * M);
+if mod(tau, 1) ~= 0
+    error('the given filter is not compatible with the input EEG signal')
+end
+
+% subtract mean from data
+channelmeans = mean(y,2);
+y = y - repmat(channelmeans, 1, T);
+
+% re-apply time lags to y to apply filter W
+[y_s, ~] = mwf_utils.stack_delay_data_sparse(y, tau,[],delay_spacing);
+
+% compute artifact estimate for original channels of y
+orig_chans = tau * M+1 : (tau+1) * M;
+d = W(:, orig_chans).' * y_s;
+
+% subtract artifact estimate from data
+n = y - d;
+
+% add mean back to filtered EEG
+n = n + repmat(channelmeans, 1, T);
+
+end

--- a/mwf/mwf_compute_sparse.m
+++ b/mwf/mwf_compute_sparse.m
@@ -1,0 +1,92 @@
+% Compute a Multi-channel Wiener Filter (MWF) based on a Generalized 
+% Eigenvalue Decompostion (GEVD) for EEG artifact removal. The filter is
+% trained on the raw EEG data y using the provided artifact mask. The
+% struct p contains additional filter settings.
+%
+% INPUTS:
+%   y       raw EEG data (channels x samples)
+%   mask    markings of artifacts in y (1 x samples)
+%   p       [optional] MWF parameter struct (see mwf_params)
+%
+% OUTPUTS: 
+%   W       multi-channel Wiener filter (size depends on number of delays)
+%   Lambda  diagonal matrix with genalized eigenvalues on main diagonal
+%
+% Author: Ben Somers, KU Leuven, Department of Neurosciences, ExpORL
+% Correspondence: ben.somers@med.kuleuven.be
+
+%% NWB added option to space out the delay stacking
+
+function [W, Lambda] = mwf_compute_sparse(y, mask, p,delay_spacing)
+
+mwf_utils.check_dimensions(size(y));
+
+if (nargin < 3) % use default settings
+    p = mwf_params;
+end
+
+switch p.treatnans
+    case 'ignore'
+        % ignore NaNs in mask
+    case 'artifact'
+        mask(isnan(mask)) = 1; % treat NaNs in mask as artifact
+    case 'clean'
+        mask(isnan(mask)) = 0; % treat NaNs in mask as clean data
+end
+
+% Include time lagged versions of y
+[y, M_s] = mwf_utils.stack_delay_data_sparse(y, p.delay,[],delay_spacing);
+
+% Calculate the covariance matrices Ryy and Rnn
+Ryy = cov(y(:,mask == 1).');
+Rnn = cov(y(:,mask == 0).');
+clear y;
+
+Ryy = mwf_utils.ensure_symmetry(Ryy);
+Rnn = mwf_utils.ensure_symmetry(Rnn);
+
+% Perform GEVD
+[V, Lambda] = eig(Ryy, Rnn);
+[V, Lambda] = mwf_utils.sort_evd(V, Lambda);
+Lambda_y = V' * Ryy * V;
+Lambda_n = V' * Rnn * V;
+Delta = Lambda_y - Lambda_n;
+
+% Eigenvectors V are assumed to be scaled such that Lambda_n is (approx.) identity
+diffs = abs(Lambda_n - eye(M_s));
+if any(diffs(:) > 1e-2)
+    warning([...
+        'Generalized eigenvectors are not scaled as assumed: results may be inacurrate. \n' ...
+        'This is likely caused by (almost) rank deficient covariance matrices. \n' ...
+        'Make sure that the EEG has full rank and that the mask provides enough' ...
+        'clean/artifact EEG samples for covariance matrix estimation.'],[])
+end
+
+% Set filter rank depending on settings
+switch p.rank
+    case 'full'     % equivalent to regular (full-rank) MWF
+        rank_w = M_s;
+        msg = sprintf(' Keeping all eigenvalues... Rank = %d\n', rank_w);
+    case 'poseig'   % only retain positive eigenvalues in rank approximation
+        rank_w = M_s - sum(diag(Delta)<0); 
+        msg = sprintf(' Rejecting %d negative eigenvalues (total: %d)... Rank = %d\n',sum(diag(Delta)<0),M_s,rank_w);
+    case 'pct'      % retain only first x% of eigenvalues
+        rank_w = ceil(p.rankopt*M_s/100);
+        msg = sprintf(' Keeping largest %d%% of %d eigenvalues... Rank = %d\n',p.rankopt,M_s,rank_w);
+    case 'first'    % retain only first x eigenvalues
+        rank_w = p.rankopt;
+        msg = sprintf(' Keeping largest %d of %d eigenvalues... Rank = %d\n',p.rankopt,M_s,rank_w);
+    otherwise
+        error('unknown rank specifier in filter parameter struct')
+end
+
+% display MWF info in command window
+if p.verbose
+    fprintf(msg)
+end
+
+% Create filter of rank specified above
+Delta(rank_w * (M_s + 1) + 1 : M_s + 1 : M_s * M_s) = 0;
+W = V / (Lambda+(p.mu-1)*eye(M_s)) * Delta / V;
+
+end

--- a/mwf/mwf_process_sparse.m
+++ b/mwf/mwf_process_sparse.m
@@ -1,0 +1,42 @@
+% Apply the full MWF chain to the input EEG data.
+%
+% INPUTS:
+%   y           raw EEG data (channels x samples)
+%   mask        markings of artifacts in y (1 x samples)
+%   delay       maximum time delay to include (samples) DEFAULT: 0 samples
+%
+% OUTPUTS: 
+%   n       filtered EEG data (channels x samples)
+%   d       estimated artifacts in every channel (channels x samples)
+%   W       MWF matrix used to estimate artifacts
+%   SER     Signal to Error Ratio, measures clean EEG distortion
+%   ARR     Artifact to Residue Ratio, measures artifact estimation
+%   p       MWF parameter struct (see mwf_params)
+%
+% USAGE
+% Only the first two inputs are required, if delay is omitted the default
+% value 0 will be used. Including delays is beneficial to MWF performance, 
+% but increases computation time. Set the 'delay' input to a positive 
+% integer for improved performance.
+%
+% Author: Ben Somers, KU Leuven, Department of Neurosciences, ExpORL
+% Correspondence: ben.somers@med.kuleuven.be
+
+%% NWB added option to spread out the delay stacking
+
+function [n, d, W, SER, ARR, p] = mwf_process_sparse(y, mask, delay, delay_spacing)
+
+mwf_utils.check_dimensions(size(y));
+
+if nargin < 3
+    delay = 0;
+end
+
+p           = mwf_params(...
+                'rank', 'poseig', ...
+                'delay', delay);
+W           = mwf_compute_sparse(y, mask, p,delay_spacing);
+[n, d]      = mwf_apply_sparse(y, W,delay_spacing);
+[SER, ARR]  = mwf_performance(y, d, mask);
+
+end


### PR DESCRIPTION
This spreads the delay embedding out, so that instead of the delay embeddings representing the consecutive and instantly preceding samples, each delay embedding can be separated by X number of samples.

The original code is left as it is, but a small number of additional functions have been added which replicate the original functions, but include the potential to implement sparse delay embedding. These functions can be identified by the "sparse" suffix. 

When cleaning blink artifacts in EEG data sampled at ~1000Hz, applying a sparse delay embedding approach, with each delay embedding separated by 16 samples and a delay period of ~8 seems to provide optimal performance (likely because the total period characterised encompasses the majority of a blink artifact).